### PR TITLE
Tag backported packages with lower version numbers

### DIFF
--- a/build_backport.sh
+++ b/build_backport.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+cd $1/
+
+debchange \
+    --local "~efs1204+0" \
+    "Backport for Precise."
+
+debuild -i -uc -us -b
+


### PR DESCRIPTION
This ensures that on upgrade to 14.04, systems will update to the
Trusty-targeted version of the same package