### PR TITLE
Ignore output files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*.deb
+*.tgz
+output/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # vim swapfiles
 .*.s??
+# output files
+*.deb
+*.tgz


### PR DESCRIPTION
This is convenient but also speeds up docker a bunch since it would
otherwise send a lot of output data as context to the daemon before
building