### PR TITLE
Build kernel meta packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN apt-get -y build-dep \
   linux-image-3.13.0-139-generic
 RUN apt-get source \
   dkms \
+  linux-meta \
   linux-image-3.13.0-139-generic
 
 # Set name and email that will appear in changelog entries
@@ -54,6 +55,7 @@ ENV EMAIL jjohnson@efolder.net
 
 COPY build_backport.sh /build
 RUN ./build_backport.sh dkms-2.2.0.3
+RUN ./build_backport.sh linux-meta-3.13.0.139.148
 RUN ./build_backport.sh linux-3.13.0
 
 # Create ad-hoc repository for easy distribution


### PR DESCRIPTION
We'll likely just use `linux-generic` to ensure we track the correct
kernel image and header packages from now on