### PR TITLE
Ship source packages and udebs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN ./build_backport.sh linux-3.13.0
 
 # Create ad-hoc repository for easy distribution
 WORKDIR /packages
-RUN mv /build/*.deb /build/*.changes /packages/
+RUN mv /build/* /packages/
 RUN dpkg-scanpackages . | gzip -9c > Packages.gz
 
 

--- a/build_backport.sh
+++ b/build_backport.sh
@@ -7,5 +7,7 @@ debchange \
     --local "~efs1204+0" \
     "Backport for Precise."
 
-debuild -i -uc -us -b
+debuild -i -uc -us
 
+cd ..
+rm -rf $1


### PR DESCRIPTION
Shipping source packages makes us GPL-compliant and makes it easier to
upload packages to our repo.

Shipping udebs makes this tool more generic and makes it easier to
upload packages to our repo.