### PR TITLE
Support custom distro, name, and email for uploads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,14 @@ RUN apt-get source \
   linux-image-3.13.0-139-generic
 
 # Set name and email that will appear in changelog entries
-ENV NAME Jared Johnson
-ENV EMAIL jjohnson@efolder.net
+ARG name="Backport Builder"
+ARG email="nowhere@example.com"
+ARG version="backport"
+ARG distribution="precise"
+ENV NAME=${name}
+ENV EMAIL=${email}
+ENV VERSION=${version}
+ENV DISTRIBUTION=${distribution}
 
 COPY build_backport.sh /build
 RUN ./build_backport.sh dkms-2.2.0.3

--- a/Readme.md
+++ b/Readme.md
@@ -4,9 +4,32 @@ There are security updates to the 3.13.0 kernel publicly available for use in Tr
 
 # Build instructions
 
+## General
+
 ```sh
 docker build -t build-kernel .
 docker run -it -v "${PWD}/output:/out" build-kernel
 ```
 
-All debian packages built in the docker container will appear in the `output` directory.
+All packages built in the docker container will appear in the `output` directory.
+
+## Replibit-specific example
+
+```sh
+rm output/*
+
+docker build \
+    --build-arg name="Jared Johnson" \
+    --build-arg email="jjohnson@efolder.net" \
+    --build-arg version="efs1204+0" \
+    --build-arg distribution="rb-precise-alpha" \
+    -t \
+    build-kernel \
+    .
+
+docker run -it -v "${PWD}/output:/out" build-kernel
+
+# dput output/*
+# scp output/* user@repository:/upload-location/
+```
+

--- a/build_backport.sh
+++ b/build_backport.sh
@@ -1,11 +1,19 @@
 #!/bin/sh
 set -e
+set -x
 
 cd $1/
 
 debchange \
-    --local "~efs1204+0" \
+    --local "~${VERSION}" \
+    --distribution "${DISTRIBUTION}" \
+    --force-distribution \
     "Backport for Precise."
+
+# Validate version change somewhat
+head -n1 debian/changelog \
+    | grep "~${VERSION}" \
+    | grep "${DISTRIBUTION}"
 
 debuild -i -uc -us
 


### PR DESCRIPTION
- Allow customizing distribution so it'll go to the right repo
- Allow customizing the rest for some generalization
- Drive-by: more debugging in `build_backport.sh`
- Drive-by: a little validation of custom version / distribution