### PR TITLE
Work around build failure on backport version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,11 @@ ENV DISTRIBUTION=${distribution}
 COPY build_backport.sh /build
 RUN ./build_backport.sh dkms-2.2.0.3
 RUN ./build_backport.sh linux-meta-3.13.0.139.148
-RUN ./build_backport.sh linux-3.13.0
+# Buid kernel with module and abi checks disabled because they fail
+# with the funky backports version number
+RUN ./build_backport.sh linux-3.13.0 \
+    --set-envvar skipmodule=true \
+    --set-envvar skipabi=true
 
 # Create ad-hoc repository for easy distribution
 WORKDIR /packages

--- a/build_backport.sh
+++ b/build_backport.sh
@@ -2,7 +2,10 @@
 set -e
 set -x
 
-for debian_dir in "${1}/debian" "${1}/debian.master"; do
+package=$1
+shift
+
+for debian_dir in "${package}/debian" "${package}/debian.master"; do
     changelog_file="${debian_dir}/changelog"
     test -f $changelog_file || continue
     echo "Modifying $changelog_file"
@@ -20,5 +23,5 @@ for debian_dir in "${1}/debian" "${1}/debian.master"; do
 
 done
 
-cd $1 && debuild -i -uc -us
-cd .. && rm -rf $1
+cd $package && debuild $@ -i -uc -us
+cd .. && rm -rf $package


### PR DESCRIPTION
Some checks that run during kernel package build expect a normal version
and break when they encounter the backport version suffix.  This passes
an environmental variable to the build which skips these checks (they
would pass :[)