### PR TITLE
Build spectre-fixed kernel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,13 +41,13 @@ RUN dpkg -i \
 RUN rm -rf /build/*
 
 # Install deps and fetch source for DKMS and kernel
-RUN apt-get -y build-dep \
+RUN apt-get update && apt-get -y build-dep \
   dkms \
-  linux-image-3.13.0-139-generic
-RUN apt-get source \
+  linux-image-3.13.0-141-generic
+RUN apt-get update && apt-get source \
   dkms \
   linux-meta \
-  linux-image-3.13.0-139-generic
+  linux-image-3.13.0-141-generic
 
 # Set name and email that will appear in changelog entries
 ARG name="Backport Builder"
@@ -61,7 +61,7 @@ ENV DISTRIBUTION=${distribution}
 
 COPY build_backport.sh /build
 RUN ./build_backport.sh dkms-2.2.0.3
-RUN ./build_backport.sh linux-meta-3.13.0.139.148
+RUN ./build_backport.sh linux-meta-3.13.0.141.151
 
 # If apt ever tries to upgrade the kernel before upgrading DKMS, it
 # will break things horribly; use Breaks: in debian/control to avoid that


### PR DESCRIPTION
Drive-by: repeat apt-get update before building primary packages so it
always works