### PR TITLE
Move kernel build step out of docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,5 +4,9 @@
 *.tgz
 *.tar.gz
 output
+ccache
+build.sh
+deploy.sh
+Makefile
 Readme.me
 LICENSE

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+OUTPUT_DIR := $(CURDIR)/output
+
+.PHONY: build clean clean-pyc lint lint-lax test
+
+clean:
+	@rm -rf $(OUTPUT_DIR)/*
+
+build:
+	@$(MAKE) clean
+	@$(CURDIR)/build.sh
+
+deploy:
+	@$(CURDIR)/deploy.sh
+

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+docker build \
+    --build-arg name="Jared Johnson" \
+    --build-arg email="jjohnson@efolder.net" \
+    --build-arg version="efs1204+0" \
+    --build-arg distribution="rb-precise-alpha" \
+    -t \
+    build-kernel \
+    .
+
+docker create \
+    -v ccache:/ccache \
+    --name ccache \
+    build-kernel
+docker run \
+    --rm \
+    --volumes-from ccache \
+    -it \
+    -v "${PWD}/output:/out" \
+    build-kernel

--- a/build_and_copy.sh
+++ b/build_and_copy.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+cd /build/
+
+# Buid kernel with module and abi checks disabled because they fail
+# with the funky backports version number
+./build_backport.sh linux-3.13.0 \
+    --preserve-envvar=CCACHE_DIR \
+    --prepend-path=/usr/lib/ccache \
+    --set-envvar skipmodule=true \
+    --set-envvar skipabi=true
+
+ccache -s
+
+#dpkg-scanpackages . | gzip -9c > Packages.gz
+
+cp * /out/

--- a/ccache/.gitignore
+++ b/ccache/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -x
+
+replace_first_line() {
+    pattern=$1
+    newline=$2
+    file=$3
+    sed -e "/.*${pattern}/{s//${newline}/;:a" -e '$!N;$!ba' -e '}' $file > $file.new
+    mv $file.new $file
+}
+
+mv output/* deploy/
+
+cd deploy
+
+rm *.udeb
+changes=linux_3.13.0-141.190~efs1204+01_amd64.changes
+
+# Remove references to .udebs which break our reprepro instance
+grep -v "\.udeb$" $changes > $changes.new
+mv $changes.new $changes
+
+# Somehow the wrong orig file is references in .changes even though
+# the right one is referenced in the .dsc
+wrong_orig=linux_3.13.0-141.190~efs1204+01_amd64.tar.gz
+rm $wrong_orig
+orig=linux_3.13.0.orig.tar.gz
+orig_size=$(wc -c $orig | awk '{print $1}')
+dsc=linux_3.13.0-141.190~efs1204+01.dsc
+
+
+sha1_line=$(grep $orig $dsc | tail -n3 | head -n1)
+replace_first_line "${wrong_orig}" "${sha1_line}" $changes
+
+sha256_line=$(grep $orig $dsc | tail -n2 | head -n1)
+replace_first_line "${wrong_orig}" "${sha256_line}" $changes
+
+md5=$(grep $orig $dsc | tail -n1 | cut -d ' ' -f 2)
+md5_line=" ${md5} ${orig_size} raw-ueif - $orig"
+replace_first_line "${wrong_orig}" "${md5_line}" $changes
+
+cd ..

--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
This is more in line with standard docker convention and allows us to
attempt to use compilercache.

Added a bunch of scripting to make it easier to get near a real upload
to our peculiar repository.

No, compilercache isn't actually working just now.